### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By leveraging InfluxDB v2, users can gain deeper insights from their time series
 
 * Official app website: <https://www.influxdata.com/>
 * Official admin documentation: <https://docs.influxdata.com/influxdb/v2.0/>
-* YunoHost documentation for this app: <https://yunohost.org/app_influxdb_v2>
+* YunoHost Store: <https://apps.yunohost.org/app/influxdb_v2>
 * Report a bug: <https://github.com/YunoHost-Apps/influxdb_v2_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -46,7 +46,7 @@ En tirant parti d'InfluxDB v2, les utilisateurs peuvent obtenir des informations
 
 * Site officiel de l’app : <https://www.influxdata.com/>
 * Documentation officielle de l’admin : <https://docs.influxdata.com/influxdb/v2.0/>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_influxdb_v2>
+* YunoHost Store: <https://apps.yunohost.org/app/influxdb_v2>
 * Signaler un bug : <https://github.com/YunoHost-Apps/influxdb_v2_ynh/issues>
 
 ## Informations pour les développeurs

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -31,8 +31,8 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
-	ynh_setup_source --dest_dir="$install_dir" --source_id=influxdb2 --keep=".influxdbv2/"
-	ynh_setup_source --dest_dir="$install_dir" --source_id=influx
+	ynh_setup_source --dest_dir="$install_dir" --source_id=influxdb2 --full_replace=1 --keep=".influxdbv2/"
+	ynh_setup_source --dest_dir="$install_dir" --source_id=influx --full_replace=1
 fi
 
 chmod -R 750 "$install_dir"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```